### PR TITLE
feat: Example ERC721 Token Mint w/ baseUri

### DIFF
--- a/project/contracts/CardCollection.sol
+++ b/project/contracts/CardCollection.sol
@@ -1,0 +1,66 @@
+// contracts/CardCollection.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "@openzeppelin/contracts/utils/Counters.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+contract CardCollection is ERC721 {
+    using Strings for uint256;
+    using Counters for Counters.Counter;
+
+    uint8 private constant PACK_SIZE = 10;
+
+    Counters.Counter private _tokenIds;
+    string private _baseUri;
+
+    // Set baseURI when we deploy the contract to the base location of the json metadata on ipfs
+    // i.e. https://gateway.pinata.cloud/ipfs/QmaBAT25ferdCHvqxqXst7cw1AKxn2r2zNjWDiHXnqVanQ/
+    constructor(string memory baseURI)
+        ERC721("HackdaysCardCollection", "CBHCC")
+    {
+        _baseUri = baseURI;
+    }
+
+    // Override token URI to concatenate _baseUri + tokenId + ".json
+    // i.e. https://gateway.pinata.cloud/ipfs/QmaBAT25ferdCHvqxqXst7cw1AKxn2r2zNjWDiHXnqVanQ/1.json
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        override
+        returns (string memory)
+    {
+        return
+            bytes(_baseUri).length > 0
+                ? string(
+                    abi.encodePacked(_baseUri, tokenId.toString(), ".json")
+                )
+                : "";
+    }
+
+    // Example buyPack function
+    function buyPack(address receiver)
+        public
+        returns (
+            uint256 /*[] memory*/
+        )
+    {
+        //* Example loop to mint 10 vs 1, maybe this should be an 1155 to save $$$
+        //uint256[] memory cards = new uint[](PACK_SIZE);
+        //for (uint8 i = 0; i < PACK_SIZE; i++) {
+
+        _tokenIds.increment();
+
+        uint256 newItemId = _tokenIds.current();
+        _safeMint(
+            receiver, // could use msg.sender here, but overriding for testing purposes
+            newItemId
+        );
+
+        //cards[i] = newItemId;
+        //}
+
+        return newItemId; /* cards */
+    }
+}

--- a/project/deploy/001_deploy_cardcollection.ts
+++ b/project/deploy/001_deploy_cardcollection.ts
@@ -1,0 +1,19 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre;
+  const { deploy } = deployments;
+
+  const { deployer } = await getNamedAccounts();
+
+  await deploy("CardCollection", {
+    from: deployer,
+    args: ["ipfs://QmaBAT25ferdCHvqxqXst7cw1AKxn2r2zNjWDiHXnqVanQ/"], // CID of json metadata folder
+    log: true,
+  });
+};
+
+export default func;
+
+func.tags = ["CardCollection"];

--- a/project/scripts/buyPack.js
+++ b/project/scripts/buyPack.js
@@ -1,0 +1,21 @@
+const hre = require("hardhat");
+
+async function main() {
+  const CardCollection = await hre.ethers.getContractFactory("CardCollection");
+  const contract = CardCollection.attach(
+    "0x0BCF70d6D894a1D195e26C2ED9381fD57F900E9b" // Deployed contract address
+  );
+  const mintedNft = await contract.buyPack(
+    "0x8243fcD2617E0708489B61AfE60342E449992b4C" // Reciever wallet address
+  );
+
+  console.log("token minted", mintedNft);
+}
+
+main()
+  // eslint-disable-next-line no-process-exit
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    throw error;
+  });


### PR DESCRIPTION
Example of minting an ERC721 Token where the BaseURI for the tokenURI metadata is set when the contract is deployed.
In this example I am using the  base URI provided by the team so this should mint the correct NFT, though it has none of the collection functionality.

Incudes:
- example deploy script with baseURI set
- example script to mint a token using hardhat run w/ `npx hardhat run scripts/buyPack.js --network ropsten`
